### PR TITLE
Update 3d tiles version, use on demand rendering in demo

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "storybook": "nx storybook storybook --port=4400 --no-open"
   },
   "dependencies": {
-    "3d-tiles-renderer": "^0.3.42",
+    "3d-tiles-renderer": "^0.3.44",
     "@here/quantized-mesh-decoder": "^1.2.8",
     "@react-three/drei": "9.117.3",
     "@react-three/fiber": "8.17.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       3d-tiles-renderer:
-        specifier: ^0.3.42
-        version: 0.3.42(three@0.170.0)
+        specifier: ^0.3.44
+        version: 0.3.44(three@0.170.0)
       '@here/quantized-mesh-decoder':
         specifier: ^1.2.8
         version: 1.2.8
@@ -336,8 +336,8 @@ importers:
 
 packages:
 
-  3d-tiles-renderer@0.3.42:
-    resolution: {integrity: sha512-GurjZ5U73clp5RDcBnBggTa1YWLE6uhniXs2fPEaUmYuuye/Dinj0q90hwnF551nmE1ZnnEmVwYw6RuJOCBdLA==}
+  3d-tiles-renderer@0.3.44:
+    resolution: {integrity: sha512-C87IqOXkE9WR5VSp0QnerPKqFDfkmAQx74FjxxL74bYBX4S5kgVuFRSEijvc+m78L7fLeSK6VpxXSUYnPfEv8A==}
     peerDependencies:
       three: '>=0.123.0'
 
@@ -8682,7 +8682,7 @@ packages:
 
 snapshots:
 
-  3d-tiles-renderer@0.3.42(three@0.170.0):
+  3d-tiles-renderer@0.3.44(three@0.170.0):
     dependencies:
       three: 0.170.0
     optionalDependencies:

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -225,6 +225,7 @@ export const Story: FC<SceneProps> = props => {
           depth: false,
           stencil: false
         }}
+        frameloop="demand"
       >
         <Stats />
         <Scene {...props} />

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -225,7 +225,7 @@ export const Story: FC<SceneProps> = props => {
           depth: false,
           stencil: false
         }}
-        frameloop="demand"
+        frameloop='demand'
       >
         <Stats />
         <Scene {...props} />


### PR DESCRIPTION
Updates 3d tiles renderer to the lastest version, which fixes the fade plugin to trigger an r3f rerender on change so we can use on demand render to lessen battery usage.