### PR TITLE
Star Component: Fix case where raycasting throws an error

### DIFF
--- a/packages/atmosphere/src/r3f/Stars.tsx
+++ b/packages/atmosphere/src/r3f/Stars.tsx
@@ -89,26 +89,25 @@ export const Stars = /*#__PURE__*/ forwardRef<StarsImpl, StarsProps>(
     })
 
     if (geometry == null) {
-      return null;
-    } else {
-      return (
-        <points
-          ref={mergeRefs([ref, forwardedRef])}
-          {...others}
-          frustumCulled={false}
-        >
-          <primitive object={geometry} />
-          <primitive
-            object={material}
-            {...atmosphereParameters}
-            pointSize={pointSize}
-            radianceScale={radianceScale}
-            background={background}
-            depthTest={true}
-            depthWrite={false}
-          />
-        </points>
-      )
+      return null
     }
+    return (
+      <points
+        ref={mergeRefs([ref, forwardedRef])}
+        {...others}
+        frustumCulled={false}
+      >
+        <primitive object={geometry} />
+        <primitive
+          object={material}
+          {...atmosphereParameters}
+          pointSize={pointSize}
+          radianceScale={radianceScale}
+          background={background}
+          depthTest={true}
+          depthWrite={false}
+        />
+      </points>
+    )
   }
 )

--- a/packages/atmosphere/src/r3f/Stars.tsx
+++ b/packages/atmosphere/src/r3f/Stars.tsx
@@ -88,23 +88,27 @@ export const Stars = /*#__PURE__*/ forwardRef<StarsImpl, StarsProps>(
       }
     })
 
-    return (
-      <points
-        ref={mergeRefs([ref, forwardedRef])}
-        {...others}
-        frustumCulled={false}
-      >
-        {geometry != null && <primitive object={geometry} />}
-        <primitive
-          object={material}
-          {...atmosphereParameters}
-          pointSize={pointSize}
-          radianceScale={radianceScale}
-          background={background}
-          depthTest={true}
-          depthWrite={false}
-        />
-      </points>
-    )
+    if (geometry == null) {
+      return null;
+    } else {
+      return (
+        <points
+          ref={mergeRefs([ref, forwardedRef])}
+          {...others}
+          frustumCulled={false}
+        >
+          <primitive object={geometry} />
+          <primitive
+            object={material}
+            {...atmosphereParameters}
+            pointSize={pointSize}
+            radianceScale={radianceScale}
+            background={background}
+            depthTest={true}
+            depthWrite={false}
+          />
+        </points>
+      )
+    }
   }
 )


### PR DESCRIPTION
Change the Star component to return "null" if `geometry` is not ready, yet. I saw some issues where `raycast` was throwing an error because geometry was undefined / un-initialized.