### PR TITLE
AerialPerspective: Assign the camera after creation to avoid breaking EffectComposer

### DIFF
--- a/packages/atmosphere/src/AerialPerspectiveEffect.ts
+++ b/packages/atmosphere/src/AerialPerspectiveEffect.ts
@@ -87,7 +87,7 @@ export class AerialPerspectiveEffect extends Effect {
   correctAltitude: boolean
 
   constructor(
-    private camera: Camera,
+    private camera: Camera | null,
     options?: AerialPerspectiveEffectOptions,
     atmosphere = AtmosphereParameters.DEFAULT
   ) {

--- a/packages/atmosphere/src/AerialPerspectiveEffect.ts
+++ b/packages/atmosphere/src/AerialPerspectiveEffect.ts
@@ -4,11 +4,11 @@
 
 import { BlendFunction, Effect, EffectAttribute } from 'postprocessing'
 import {
+  Camera,
   Matrix4,
   Uniform,
   Vector2,
   Vector3,
-  type Camera,
   type Data3DTexture,
   type DataTexture,
   type Texture,
@@ -87,7 +87,7 @@ export class AerialPerspectiveEffect extends Effect {
   correctAltitude: boolean
 
   constructor(
-    private camera: Camera | null,
+    private camera = new Camera(),
     options?: AerialPerspectiveEffectOptions,
     atmosphere = AtmosphereParameters.DEFAULT
   ) {
@@ -200,9 +200,6 @@ export class AerialPerspectiveEffect extends Effect {
     inputBuffer: WebGLRenderTarget,
     deltaTime?: number
   ): void {
-    if (this.camera == null) {
-      return
-    }
     const uniforms = this.uniforms
     const projectionMatrix = uniforms.get('projectionMatrix')!
     const inverseProjectionMatrix = uniforms.get('inverseProjectionMatrix')!

--- a/packages/atmosphere/src/r3f/AerialPerspective.tsx
+++ b/packages/atmosphere/src/r3f/AerialPerspective.tsx
@@ -46,7 +46,7 @@ export const AerialPerspective = /*#__PURE__*/ forwardRef<
       : undefined
 
   const effect = useMemo(
-    () => new AerialPerspectiveEffect(null, { blendFunction }),
+    () => new AerialPerspectiveEffect(undefined, { blendFunction }),
     [blendFunction]
   )
 

--- a/packages/atmosphere/src/r3f/AerialPerspective.tsx
+++ b/packages/atmosphere/src/r3f/AerialPerspective.tsx
@@ -46,9 +46,16 @@ export const AerialPerspective = /*#__PURE__*/ forwardRef<
       : undefined
 
   const effect = useMemo(
-    () => new AerialPerspectiveEffect(camera, { blendFunction }),
-    [camera, blendFunction]
+    () => new AerialPerspectiveEffect(null, { blendFunction }),
+    [blendFunction]
   )
+
+  // assign the camera after-the-fact to avoid EffectComposer effect out-of-order problem when
+  // recreating effect passes
+  useEffect(() => {
+    effect.mainCamera = camera;
+  }, [camera, effect]);
+
   useEffect(() => {
     return () => {
       effect.dispose()

--- a/packages/atmosphere/src/r3f/AerialPerspective.tsx
+++ b/packages/atmosphere/src/r3f/AerialPerspective.tsx
@@ -50,12 +50,6 @@ export const AerialPerspective = /*#__PURE__*/ forwardRef<
     [blendFunction]
   )
 
-  // assign the camera after-the-fact to avoid EffectComposer effect out-of-order problem when
-  // recreating effect passes
-  useEffect(() => {
-    effect.mainCamera = camera;
-  }, [camera, effect]);
-
   useEffect(() => {
     return () => {
       effect.dispose()
@@ -72,7 +66,7 @@ export const AerialPerspective = /*#__PURE__*/ forwardRef<
     <primitive
       ref={forwardedRef}
       object={effect}
-      camera={camera}
+      mainCamera={camera}
       normalBuffer={geometryTexture ?? normalPass?.texture ?? null}
       {...atmosphereParameters}
       {...others}


### PR DESCRIPTION
Fix #17 

It seems the EffectComposer bug discovered in #17 happens when passes are recreated which was caused by assigning a new camera. This PR fixes that by using the same effect instance and just reassigning the camera, instead.

I'm getting the following type issue now, though, since this change adjusts "camera" to be nullable. Not sure how you'd like to fix it:

<img width="508" alt="image" src="https://github.com/user-attachments/assets/2e099054-4ace-41f6-af2d-cfe7c7b5e7a8">
