### PR TITLE
Photorealistic Tiles Demo: Add "orthographic camera" toggle

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "storybook": "nx storybook storybook --port=4400 --no-open"
   },
   "dependencies": {
-    "3d-tiles-renderer": "^0.3.44",
+    "3d-tiles-renderer": "^0.3.45",
     "@here/quantized-mesh-decoder": "^1.2.8",
     "@react-three/drei": "9.120.4",
     "@react-three/fiber": "8.17.10",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       3d-tiles-renderer:
-        specifier: ^0.3.44
-        version: 0.3.44(three@0.170.0)
+        specifier: ^0.3.45
+        version: 0.3.45(three@0.170.0)
       '@here/quantized-mesh-decoder':
         specifier: ^1.2.8
         version: 1.2.8
@@ -336,8 +336,8 @@ importers:
 
 packages:
 
-  3d-tiles-renderer@0.3.44:
-    resolution: {integrity: sha512-C87IqOXkE9WR5VSp0QnerPKqFDfkmAQx74FjxxL74bYBX4S5kgVuFRSEijvc+m78L7fLeSK6VpxXSUYnPfEv8A==}
+  3d-tiles-renderer@0.3.45:
+    resolution: {integrity: sha512-75RzRaOlXLj1Esg+twqAJiFVKX5Va5ffTztvWEYxvzGgqJEEB9ECF2BmpyCZitGgRHOk8/AtiXIheTRdvctM/g==}
     peerDependencies:
       three: '>=0.123.0'
 
@@ -8757,7 +8757,7 @@ packages:
 
 snapshots:
 
-  3d-tiles-renderer@0.3.44(three@0.170.0):
+  3d-tiles-renderer@0.3.45(three@0.170.0):
     dependencies:
       three: 0.170.0
     optionalDependencies:

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -11,7 +11,8 @@ import {
 import {
   GlobeControls,
   TilesPlugin,
-  TilesRenderer
+  TilesRenderer,
+  CameraTransition,
 } from '3d-tiles-renderer/r3f'
 import { useAtom, useAtomValue } from 'jotai'
 import {
@@ -90,6 +91,7 @@ const Scene: FC<SceneProps> = ({
   heading = 180,
   pitch = -30,
   distance = 4500,
+  perspective,
   ...localDate
 }) => {
   useExposureControls({ exposure })
@@ -209,7 +211,10 @@ const Scene: FC<SceneProps> = ({
 
 export const Story: FC<SceneProps> = props => {
   const [apiKey, setApiKey] = useAtom(googleMapsApiKeyAtom)
-  useControls('google maps', {
+  const { orthographic } = useControls('google maps', {
+    orthographic: {
+      value: false,
+    },
     apiKey: {
       value: apiKey,
       onChange: value => {
@@ -229,6 +234,7 @@ export const Story: FC<SceneProps> = props => {
       >
         <Stats />
         <Scene {...props} />
+        <CameraTransition mode={ orthographic ? 'orthographic' : 'perspective' } />
       </Canvas>
       {apiKey === '' && (
         <div

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -94,6 +94,11 @@ const Scene: FC<SceneProps> = ({
   ...localDate
 }) => {
   useExposureControls({ exposure })
+  const { orthographic } = useControls(
+    'camera',
+    { orthographic: false },
+    { collapsed: true }
+  )
   const lut = useColorGradingControls()
   const { lensFlare, normal, depth } = useControls(
     'effects',
@@ -209,14 +214,14 @@ const Scene: FC<SceneProps> = ({
           )}
         </Fragment>
       </EffectComposer>
+      <CameraTransition mode={orthographic ? 'orthographic' : 'perspective'} />
     </Atmosphere>
   )
 }
 
 export const Story: FC<SceneProps> = props => {
   const [apiKey, setApiKey] = useAtom(googleMapsApiKeyAtom)
-  const { orthographic } = useControls('google maps', {
-    orthographic: false,
+  useControls('google maps', {
     apiKey: {
       value: apiKey,
       onChange: value => {
@@ -236,11 +241,6 @@ export const Story: FC<SceneProps> = props => {
       >
         <Stats />
         <Scene {...props} />
-        <CameraTransition
-          // TODO: ESLint claims false positive error, perhaps due to mismatch
-          // in TS version.
-          mode={orthographic ? 'orthographic' : 'perspective'}
-        />
       </Canvas>
       {apiKey === '' && (
         <div

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -91,7 +91,6 @@ const Scene: FC<SceneProps> = ({
   heading = 180,
   pitch = -30,
   distance = 4500,
-  perspective,
   ...localDate
 }) => {
   useExposureControls({ exposure })

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -130,6 +130,11 @@ const Scene: FC<SceneProps> = ({
 
   const camera = useThree(({ camera }) => camera)
   useLayoutEffect(() => {
+    // Check the camera position to see if we've already moved it to globe surface
+    if (camera.position.length() > 10) {
+      return
+    }
+
     new PointOfView(distance, radians(heading), radians(pitch)).decompose(
       new Geodetic(radians(longitude), radians(latitude)).toECEF(),
       camera.position,

--- a/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
+++ b/storybook/src/atmosphere/PhotorealisticTiles-Story.tsx
@@ -9,10 +9,10 @@ import {
   UpdateOnChangePlugin
 } from '3d-tiles-renderer/plugins'
 import {
+  CameraTransition,
   GlobeControls,
   TilesPlugin,
-  TilesRenderer,
-  CameraTransition,
+  TilesRenderer
 } from '3d-tiles-renderer/r3f'
 import { useAtom, useAtomValue } from 'jotai'
 import {
@@ -216,9 +216,7 @@ const Scene: FC<SceneProps> = ({
 export const Story: FC<SceneProps> = props => {
   const [apiKey, setApiKey] = useAtom(googleMapsApiKeyAtom)
   const { orthographic } = useControls('google maps', {
-    orthographic: {
-      value: false,
-    },
+    orthographic: false,
     apiKey: {
       value: apiKey,
       onChange: value => {
@@ -238,7 +236,11 @@ export const Story: FC<SceneProps> = props => {
       >
         <Stats />
         <Scene {...props} />
-        <CameraTransition mode={ orthographic ? 'orthographic' : 'perspective' } />
+        <CameraTransition
+          // TODO: ESLint claims false positive error, perhaps due to mismatch
+          // in TS version.
+          mode={orthographic ? 'orthographic' : 'perspective'}
+        />
       </Canvas>
       {apiKey === '' && (
         <div

--- a/storybook/types/3d-tiles-renderer-r3f.d.ts
+++ b/storybook/types/3d-tiles-renderer-r3f.d.ts
@@ -1,12 +1,17 @@
 declare module '3d-tiles-renderer/r3f' {
   import { type GlobeControls, type TilesRenderer } from '3d-tiles-renderer'
-  import { type RefAttributes } from 'react'
+  import { type FC, type RefAttributes } from 'react'
 
-  export function TilesPlugin<T extends new (...args: any[]) => any>(
+  export function TilesPlugin<
+    T extends new (...args: any[]) => any,
+    Params extends {} = ConstructorParameters<T>[0] extends {}
+      ? ConstructorParameters<T>[0]
+      : {}
+  >(
     props: {
-      args?: ConstructorParameters<T>[0]
+      args?: Params
       plugin: T
-    } & Partial<ConstructorParameters<T>[0]> &
+    } & Partial<Params> &
       RefAttributes<T>
   ): JSX.Element
 
@@ -22,8 +27,7 @@ declare module '3d-tiles-renderer/r3f' {
       RefAttributes<GlobeControls>
   ): JSX.Element
 
-  export function CameraTransition<T extends new (...args: any[]) => any>(
-    props: {} & Partial<ConstructorParameters<T>[0]> &
-      RefAttributes<GlobeControls>
-  ): JSX.Element
+  const CameraTransition: FC<{
+    mode: 'perspective' | 'orthographic'
+  }>
 }

--- a/storybook/types/3d-tiles-renderer-r3f.d.ts
+++ b/storybook/types/3d-tiles-renderer-r3f.d.ts
@@ -27,7 +27,7 @@ declare module '3d-tiles-renderer/r3f' {
       RefAttributes<GlobeControls>
   ): JSX.Element
 
-  const CameraTransition: FC<{
+  export const CameraTransition: FC<{
     mode: 'perspective' | 'orthographic'
   }>
 }

--- a/storybook/types/3d-tiles-renderer-r3f.d.ts
+++ b/storybook/types/3d-tiles-renderer-r3f.d.ts
@@ -21,4 +21,9 @@ declare module '3d-tiles-renderer/r3f' {
     props: {} & Partial<ConstructorParameters<T>[0]> &
       RefAttributes<GlobeControls>
   ): JSX.Element
+
+  export function CameraTransition<T extends new (...args: any[]) => any>(
+    props: {} & Partial<ConstructorParameters<T>[0]> &
+      RefAttributes<GlobeControls>
+  ): JSX.Element
 }


### PR DESCRIPTION
Adds an "orthographic" option to the demo with a transition. I had to make a bug fix in the tiles renderer to support "on demand rendering" with the transition component so that version is updated, as well.