### PR TITLE
Fix shadows not rendering with orthographic render

### DIFF
--- a/packages/atmosphere/README.md
+++ b/packages/atmosphere/README.md
@@ -940,14 +940,13 @@ correctAltitude: boolean = true
 
 See [correctAltitude](#correctaltitude)
 
-#### correctGeometricError, geometricErrorAltitudeRange
+#### correctGeometricError
 
 ```ts
 correctGeometricError: boolean = true
-geometricErrorAltitudeRange: Vector2 = new Vector2(2e5, 6e5)
 ```
 
-These options corrects artifacts caused by geometric errors in surface tiles. The Earth’s surface normals are gradually morphed to a true sphere within the altitude range specified by `geometricErrorAltitudeRange`, in meters.
+These options corrects lighting artifacts caused by geometric errors in surface tiles. The Earth’s surface normals are gradually morphed to a true sphere.
 
 Disable this option if your scene contains objects that penetrate the atmosphere or are located in space.
 

--- a/packages/atmosphere/src/AerialPerspectiveEffect.ts
+++ b/packages/atmosphere/src/AerialPerspectiveEffect.ts
@@ -218,9 +218,8 @@ export class AerialPerspectiveEffect extends Effect {
     // interpolate between the globe true normals and idealized normals to avoid
     // lighting artifacts
     const idealSphereAlphaUniform = uniforms.get('idealSphereAlpha')!
-    const distanceToSurface = geodeticScratch.setFromECEF(position).height
     vectorScratch
-      .set(0, this.ellipsoid.maximumRadius, -distanceToSurface)
+      .set(0, this.ellipsoid.maximumRadius, -cameraHeight.value)
       .applyMatrix4(camera.projectionMatrix)
 
     // calculate interpolation alpha

--- a/packages/atmosphere/src/AerialPerspectiveEffect.ts
+++ b/packages/atmosphere/src/AerialPerspectiveEffect.ts
@@ -226,6 +226,7 @@ export class AerialPerspectiveEffect extends Effect {
     // calculate interpolation alpha
     // interpolation values are picked to match previous rough globe scales to
     // match the previous "camera height" approach for interpolation
+    // See: https://github.com/takram-design-engineering/three-geospatial/pull/23
     let a = MathUtils.mapLinear(vectorScratch.y, 41.5, 13.8, 0, 1)
     a = MathUtils.clamp(a, 0, 1)
     idealSphereAlphaUniform.value = a

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
@@ -7,6 +7,7 @@ uniform float cameraHeight;
 uniform vec2 geometricErrorAltitudeRange;
 uniform vec3 sunDirection;
 uniform float irradianceScale;
+uniform vec3 ellipsoidRadii;
 
 varying vec3 vWorldPosition;
 varying vec3 vEllipsoidCenter;
@@ -26,12 +27,16 @@ void correctGeometricError(
   inout vec3 worldPosition,
   inout vec3 worldNormal
 ) {
-  vec3 normal = normalize(1.0 / vEllipsoidRadiiSquared * worldPosition);
-  vec3 position = u_bottom_radius * normal;
-  float t = smoothstep(minHeight, maxHeight, cameraHeight);
-  worldPosition = mix(worldPosition, position, t);
+  // calculate the projected scale of the globe in clip space
+  float maxRadius = max(ellipsoidRadii.x, max(ellipsoidRadii.y, ellipsoidRadii.z));
+  vec4 projectedPoint = projectionMatrix * vec4(0, maxRadius, - cameraHeight, 1);
+  projectedPoint /= projectedPoint.w;
+
+  // transition between the zoomed out and zoomed in normals based on projected size
+  float t = smoothstep( 41.5, 13.8, projectedPoint.y );
+
   // Correct way is slerp, but this will be small-angle interpolation anyways.
-  worldNormal = mix(worldNormal, normal, t);
+  worldNormal = mix(worldNormal, normal, a);
 }
 
 #if defined(SUN_IRRADIANCE) || defined(SKY_IRRADIANCE)

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
@@ -7,6 +7,7 @@ uniform float cameraHeight;
 uniform vec3 sunDirection;
 uniform float irradianceScale;
 uniform vec3 ellipsoidRadii;
+uniform float idealSphereAlpha;
 
 varying vec3 vWorldPosition;
 varying vec3 vEllipsoidCenter;
@@ -21,19 +22,11 @@ vec3 readNormal(const vec2 uv) {
 }
 
 void correctGeometricError(inout vec3 worldPosition, inout vec3 worldNormal) {
-  // calculate the projected scale of the globe in clip space
-  float maxRadius = max(ellipsoidRadii.x, max(ellipsoidRadii.y, ellipsoidRadii.z));
-  vec4 projectedPoint = projectionMatrix * vec4(0, maxRadius, - cameraHeight, 1);
-  projectedPoint /= projectedPoint.w;
-
-  // transition between the zoomed out and zoomed in normals based on projected size
-  float t = smoothstep(41.5, 13.8, projectedPoint.y);
-
   // Correct way is slerp, but this will be small-angle interpolation anyways.
   vec3 normal = normalize(1.0 / vEllipsoidRadiiSquared * worldPosition);
   vec3 position = u_bottom_radius * normal;
-  worldNormal = mix(worldNormal, normal, t);
-  worldPosition = mix(worldPosition, position, t);
+  worldNormal = mix(worldNormal, normal, idealSphereAlpha);
+  worldPosition = mix(worldPosition, position, idealSphereAlpha);
 }
 
 #if defined(SUN_IRRADIANCE) || defined(SKY_IRRADIANCE)

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
@@ -31,7 +31,9 @@ void correctGeometricError(inout vec3 worldPosition, inout vec3 worldNormal) {
 
   // Correct way is slerp, but this will be small-angle interpolation anyways.
   vec3 normal = normalize(1.0 / vEllipsoidRadiiSquared * worldPosition);
+  vec3 position = u_bottom_radius * normal;
   worldNormal = mix(worldNormal, normal, t);
+  worldPosition = mix(worldPosition, position, t);
 }
 
 #if defined(SUN_IRRADIANCE) || defined(SKY_IRRADIANCE)

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
@@ -6,7 +6,6 @@ uniform mat4 inverseViewMatrix;
 uniform float cameraHeight;
 uniform vec3 sunDirection;
 uniform float irradianceScale;
-uniform vec3 ellipsoidRadii;
 uniform float idealSphereAlpha;
 
 varying vec3 vWorldPosition;

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.vert
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.vert
@@ -4,7 +4,6 @@ uniform vec3 cameraPosition;
 uniform float cameraHeight;
 uniform vec3 ellipsoidCenter;
 uniform vec3 ellipsoidRadii;
-uniform vec2 geometricErrorAltitudeRange;
 uniform float idealSphereAlpha;
 
 varying vec3 vWorldPosition;

--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.vert
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.vert
@@ -5,6 +5,7 @@ uniform float cameraHeight;
 uniform vec3 ellipsoidCenter;
 uniform vec3 ellipsoidRadii;
 uniform vec2 geometricErrorAltitudeRange;
+uniform float idealSphereAlpha;
 
 varying vec3 vWorldPosition;
 varying vec3 vEllipsoidCenter;
@@ -43,12 +44,7 @@ void mainSupport() {
   vWorldPosition = origin * METER_TO_UNIT_LENGTH;
 
   #ifdef CORRECT_GEOMETRIC_ERROR
-  float t = smoothstep(
-    geometricErrorAltitudeRange.x,
-    geometricErrorAltitudeRange.y,
-    cameraHeight
-  );
-  vEllipsoidCenter = mix(ellipsoidCenter, vec3(0.0), t) * METER_TO_UNIT_LENGTH;
+  vEllipsoidCenter = mix(ellipsoidCenter, vec3(0.0), idealSphereAlpha) * METER_TO_UNIT_LENGTH;
   #else
   vEllipsoidCenter = ellipsoidCenter * METER_TO_UNIT_LENGTH;
   #endif // CORRECT_GEOMETRIC_ERROR

--- a/packages/atmosphere/src/shaders/stars.frag
+++ b/packages/atmosphere/src/shaders/stars.frag
@@ -12,7 +12,7 @@ in vec3 vColor;
 
 void main() {
   #ifndef PERSPECTIVE_CAMERA
-  outputColor = vec4(0,0,0,0);
+  outputColor = vec4(0.0);
   discard; // Rendering celestial objects without perspective doesn't make sense.
   #endif
 

--- a/packages/atmosphere/src/shaders/stars.frag
+++ b/packages/atmosphere/src/shaders/stars.frag
@@ -12,6 +12,7 @@ in vec3 vColor;
 
 void main() {
   #ifndef PERSPECTIVE_CAMERA
+  outputColor = vec4(0,0,0,0);
   discard; // Rendering celestial objects without perspective doesn't make sense.
   #endif
 


### PR DESCRIPTION
Fix #21 

Instead of using the height to determine which set of normals to use and interpolate we use the projected size of the globe at the surface of the ellipsoid. The min and max interpolation factors were chosen to roughly match the two heights / transition points that were previously chosen with the existing perspective camera fov.

Another benefit of this is that these settings will automatically account for different perspective camera FoVs in addition to an orthographic projection. With this change the `geometricErrorAltitudeRange` is no longer needed unless we want to expose the min / max parameters as variables.

_Also_ this interpolation value can be computed on the CPU and passed as a uniform which would simplify some of the shader calculations. If you'd like me to move the calculation I can do that, as well!

Perspective / Orthographic Shadows

<img height="250" alt="image" src="https://github.com/user-attachments/assets/448936aa-5bd0-452e-89f2-4f63246d8901" /> <img height="250" alt="image" src="https://github.com/user-attachments/assets/03edd688-bf4f-4c7a-8b75-4dcc54fa3b8c" />



