### PR TITLE
fix: apply logarithmicDepthBuffer automatically in clouds

### DIFF
--- a/packages/clouds/src/CloudsMaterial.ts
+++ b/packages/clouds/src/CloudsMaterial.ts
@@ -270,6 +270,17 @@ export class CloudsMaterial extends AtmosphereMaterialBase {
     // Disable onBeforeRender in AtmosphereMaterialBase because we're rendering
     // into fullscreen quad with another camera for the scene projection.
 
+    const prevLogarithmicDepthBuffer = this.defines.USE_LOGDEPTHBUF != null
+    const nextLogarithmicDepthBuffer =
+      renderer.capabilities.logarithmicDepthBuffer
+    if (nextLogarithmicDepthBuffer !== prevLogarithmicDepthBuffer) {
+      if (nextLogarithmicDepthBuffer) {
+        this.defines.USE_LOGDEPTHBUF = '1'
+      } else {
+        delete this.defines.USE_LOGDEPTHBUF
+      }
+    }
+
     const prevPowder = this.defines.POWDER != null
     const nextPowder = this.uniforms.powderScale.value > 0
     if (nextPowder !== prevPowder) {
@@ -292,16 +303,6 @@ export class CloudsMaterial extends AtmosphereMaterialBase {
         delete this.defines.GROUND_IRRADIANCE
       }
       this.needsUpdate = true
-    }
-
-    const prevLogarithmicDepthBuffer = this.defines.USE_LOGDEPTHBUF != null;
-    const nextLogarithmicDepthBuffer = renderer.capabilities.logarithmicDepthBuffer;
-    if(prevLogarithmicDepthBuffer !== nextLogarithmicDepthBuffer) {
-      if(nextLogarithmicDepthBuffer) {
-        this.defines.USE_LOGDEPTHBUF = '1';
-      } else {
-        delete this.defines.USE_LOGDEPTHBUF;
-      }
     }
   }
 

--- a/packages/clouds/src/CloudsMaterial.ts
+++ b/packages/clouds/src/CloudsMaterial.ts
@@ -293,6 +293,16 @@ export class CloudsMaterial extends AtmosphereMaterialBase {
       }
       this.needsUpdate = true
     }
+
+    const prevLogarithmicDepthBuffer = this.defines.USE_LOGDEPTHBUF != null;
+    const nextLogarithmicDepthBuffer = renderer.capabilities.logarithmicDepthBuffer;
+    if(prevLogarithmicDepthBuffer !== nextLogarithmicDepthBuffer) {
+      if(nextLogarithmicDepthBuffer) {
+        this.defines.USE_LOGDEPTHBUF = '1';
+      } else {
+        delete this.defines.USE_LOGDEPTHBUF;
+      }
+    }
   }
 
   override copyCameraSettings(camera: Camera): void {


### PR DESCRIPTION
When I enable `logarithmicDepthBuffer`, `CloudsEffect` doesn't take an effect. Although `reverseLogDepth` function handles log depth, I noticed that `USE_LOGDEPTHBUF` isn't passed to `defines`.

I would appreciate it if you could review this PR and let me know if any changes are needed.

Thank you!

**Before**

https://github.com/user-attachments/assets/a9ff022c-5640-4645-a06b-6cc66d36c311

**After**

https://github.com/user-attachments/assets/2c5a4008-0bf3-4e96-9f84-08683ebdcc8a

