### PR TITLE
fix(storybook): load env vars from root and add Cesium Ion fallback t…

### DIFF
--- a/storybook-webgpu/.storybook/main.ts
+++ b/storybook-webgpu/.storybook/main.ts
@@ -1,11 +1,14 @@
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import type { StorybookConfig } from '@storybook/react-vite'
 import react from '@vitejs/plugin-react'
 import { mergeConfig } from 'vite'
 
 const require = createRequire(import.meta.url)
+const currentDir = dirname(fileURLToPath(import.meta.url))
+const repoRoot = resolve(currentDir, '..', '..')
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
@@ -24,6 +27,7 @@ const config: StorybookConfig = {
   viteFinal: config =>
     mergeConfig(config, {
       plugins: [react(), nxViteTsPaths()],
+      envDir: repoRoot,
       worker: {
         plugins: () => [nxViteTsPaths()]
       },

--- a/storybook/.storybook/main.ts
+++ b/storybook/.storybook/main.ts
@@ -1,11 +1,12 @@
 import { createRequire } from 'node:module'
-import { dirname, join } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'
 import type { StorybookConfig } from '@storybook/react-vite'
 import react from '@vitejs/plugin-react'
 import { mergeConfig } from 'vite'
 
 const require = createRequire(import.meta.url)
+const repoRoot = resolve(dirname(require.resolve(join('..', '..', 'package.json'))))
 
 const config: StorybookConfig = {
   stories: ['../src/**/*.@(mdx|stories.@(js|jsx|ts|tsx))'],
@@ -38,6 +39,7 @@ const config: StorybookConfig = {
   viteFinal: config =>
     mergeConfig(config, {
       plugins: [react(), nxViteTsPaths()],
+      envDir: repoRoot,
       worker: {
         plugins: () => [nxViteTsPaths()]
       },


### PR DESCRIPTION
## Fix Storybook Environment Variable Loading and Add Cesium Ion Fallback

### Problem
Storybook was not loading environment variables from the root `.env` file, causing `STORYBOOK_ION_API_TOKEN` to be undefined in stories. Additionally, the Fuji example required a Google Maps API key and would fail to load tiles if only Cesium Ion token was configured.

### Solution

#### 1. Fixed Environment Variable Loading
- Added `envDir: repoRoot` to both `storybook/.storybook/main.ts` and `storybook-webgpu/.storybook/main.ts`
- This ensures Vite loads environment variables from the repository root where the `.env` file is located
- All stories can now access `import.meta.env.STORYBOOK_ION_API_TOKEN` and other env vars

#### 2. Added Cesium Ion Fallback to Fuji Example
- Updated `3DTilesRenderer-Story.tsx` to fallback to Cesium Ion (Japan Regional Terrain, asset 2767062) when Google Maps API key is not available
- Improves developer experience by allowing the example to work with just the Cesium Ion token
- Maintains backward compatibility - still uses Google Cloud tiles if API key is provided

### Changes
- `storybook/.storybook/main.ts`: Added `repoRoot` calculation and `envDir` config
- `storybook-webgpu/.storybook/main.ts`: Added `repoRoot` calculation and `envDir` config  
- `storybook-webgpu/src/atmosphere/3DTilesRenderer-Story.tsx`: Added Cesium Ion fallback logic
