### PR TITLE
fix: a depth error by postprocessing readDepth

### DIFF
--- a/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
+++ b/packages/atmosphere/src/shaders/aerialPerspectiveEffect.frag
@@ -285,7 +285,7 @@ void mainImage(const vec4 inputColor, const vec2 uv, out vec4 outputColor) {
   }
   #endif // HAS_OVERLAY
 
-  float depth = readRawDepth(uv);
+  float depth = readRawDepth(depthBuffer, uv);
   if (depth >= 1.0 - 1e-8) {
     #ifdef SKY
     vec3 rayDirection = normalize(vRayDirection);

--- a/packages/clouds/src/shaders/clouds.frag
+++ b/packages/clouds/src/shaders/clouds.frag
@@ -810,7 +810,7 @@ vec2 getHazeRayNearFar(const IntersectionResult intersections) {
 #endif // HAZE
 
 float getRayDistanceToScene(const vec3 rayDirection, out float viewZ) {
-  float depth = readRawDepth(vUv * targetUvScale + temporalJitter);
+  float depth = readRawDepth(depthBuffer, vUv * targetUvScale + temporalJitter);
   if (depth < 1.0 - 1e-7) {
     depth = reverseLogDepth(depth, cameraNear, cameraFar);
     viewZ = getViewZ(depth);

--- a/packages/core/src/shaders/depth.glsl
+++ b/packages/core/src/shaders/depth.glsl
@@ -1,6 +1,6 @@
 // cSpell:words logdepthbuf
 
-float readRawDepth(const vec2 uv) {
+float readRawDepth(const sampler2D depthBuffer, const vec2 uv) {
   #if DEPTH_PACKING == 3201
   return unpackRGBAToDepth(texture(depthBuffer, uv));
   #else // DEPTH_PACKING == 3201

--- a/packages/effects/src/shaders/depthEffect.frag
+++ b/packages/effects/src/shaders/depthEffect.frag
@@ -5,7 +5,7 @@ uniform float near;
 uniform float far;
 
 void mainImage(const vec4 inputColor, const vec2 uv, out vec4 outputColor) {
-  float depth = readRawDepth(uv);
+  float depth = readRawDepth(depthBuffer, uv);
   depth = reverseLogDepth(depth, cameraNear, cameraFar);
   depth = linearizeDepth(depth, near, far) / far;
 

--- a/packages/effects/src/shaders/normalEffect.frag
+++ b/packages/effects/src/shaders/normalEffect.frag
@@ -8,7 +8,7 @@ uniform mat4 projectionMatrix;
 uniform mat4 inverseProjectionMatrix;
 
 vec3 reconstructNormal(const vec2 uv) {
-  float depth = readRawDepth(uv);
+  float depth = readRawDepth(depthBuffer, uv);
   depth = reverseLogDepth(depth, cameraNear, cameraFar);
   vec3 position = screenToView(
     uv,


### PR DESCRIPTION
Related issue: https://github.com/takram-design-engineering/three-geospatial/issues/100

`postprocessing` library updated `readDepth` built-in function to return the converted depth. They mentioned the update in https://github.com/takram-design-engineering/three-geospatial/issues/100 .

This update causes a depth error when I use `logarithmicDepth`.

I added `readRawDepth` to fix the depth error.

**Before**

https://github.com/user-attachments/assets/fceaeae7-b92b-43d1-bfeb-7c24671ce3ea

**After**

https://github.com/user-attachments/assets/93789053-daf0-45d0-9d17-63b312b2a845

Thank you!