### PR TITLE
fix: revert to the log depth conversion for the clouds effect

### DIFF
--- a/packages/clouds/src/shaders/clouds.frag
+++ b/packages/clouds/src/shaders/clouds.frag
@@ -5,6 +5,7 @@ precision highp sampler2DArray;
 #include <common>
 #include <packing>
 
+#include "core/depth"
 #include "core/math"
 #include "core/turbo"
 #include "core/generators"
@@ -818,6 +819,7 @@ vec2 getHazeRayNearFar(const IntersectionResult intersections) {
 
 float getRayDistanceToScene(const vec3 rayDirection, out float viewZ) {
   float depth = readDepth(vUv * targetUvScale + temporalJitter);
+  depth = reverseLogDepth(depth, cameraNear, cameraFar);
   if (depth < 1.0 - 1e-7) {
     viewZ = getViewZ(depth);
     return -viewZ / dot(rayDirection, vCameraDirection);


### PR DESCRIPTION
I found an issue that CloudsEffect doesn't render the clouds well.
The cause was that [this commit](https://github.com/takram-design-engineering/three-geospatial/commit/7c9c3ae44c834a2ed259ace294896bfe091f3a55) removed the log depth conversion for clouds.frag. Since it isn't depending on postprocessing's EffectMaterial, I think the conversion should be preserved. 

|Before|After
|:--:|:--:|
|<img width="1514" height="792" alt="Screenshot 2026-03-10 at 13 11 14" src="https://github.com/user-attachments/assets/9cdac43f-0eae-4f38-adc1-a0665202d764" />|<img width="1514" height="792" alt="Screenshot 2026-03-10 at 13 10 58" src="https://github.com/user-attachments/assets/88316046-aa46-4cd9-83b9-e95d4d576f6c" />|

Thank you 🙏 